### PR TITLE
Introduce task pool to manage Eagle tasks

### DIFF
--- a/src/addon.ts
+++ b/src/addon.ts
@@ -3,6 +3,7 @@ import { ColumnOptions, DialogHelper } from "zotero-plugin-toolkit";
 import hooks from "./hooks";
 import { createZToolkit } from "./utils/ztoolkit";
 import PDFButton from "./modules/pdfButton";
+import TaskPool from "./utils/taskPool";
 
 class Addon {
   public data: {
@@ -22,6 +23,7 @@ class Addon {
     };
     dialog?: DialogHelper;
     pdfButton: PDFButton;
+    taskPool: TaskPool;
   };
   // Lifecycle hooks
   public hooks: typeof hooks;
@@ -36,6 +38,7 @@ class Addon {
       initialized: false,
       ztoolkit: createZToolkit(),
       pdfButton: new PDFButton(),
+      taskPool: new TaskPool(),
     };
     this.hooks = hooks;
     this.api = {};

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -113,6 +113,7 @@ async function onMainWindowUnload(win: Window): Promise<void> {
 
 async function onShutdown(): Promise<void> {
   await FileLogger.info("Shutdown", "Zotero2Eagle plugin shutting down");
+  await addon.data.taskPool.drain();
   ztoolkit.unregisterAll();
   addon.data.dialog?.window?.close();
   // Remove PDF button

--- a/src/utils/taskPool.ts
+++ b/src/utils/taskPool.ts
@@ -1,0 +1,34 @@
+import { FileLogger } from "./fileLogger";
+
+export type Task = () => Promise<any>;
+
+export default class TaskPool {
+  private tasks: Set<Promise<any>> = new Set();
+
+  add(task: Task, retries = 0) {
+    const wrapped = async () => {
+      let attempt = 0;
+      while (true) {
+        try {
+          return await task();
+        } catch (e) {
+          attempt++;
+          if (attempt > retries) {
+            try {
+            await FileLogger.log("ERROR", "TaskPool", String(e));
+          } catch {
+            /* ignore logging errors */
+          }
+            throw e;
+          }
+        }
+      }
+    };
+    const promise = wrapped().finally(() => this.tasks.delete(promise));
+    this.tasks.add(promise);
+  }
+
+  async drain() {
+    await Promise.all(Array.from(this.tasks));
+  }
+}

--- a/test/taskPool.test.ts
+++ b/test/taskPool.test.ts
@@ -1,0 +1,27 @@
+import { assert } from "chai";
+import TaskPool from "../src/utils/taskPool";
+
+describe("TaskPool", function () {
+  it("runs tasks and clears them", async function () {
+    const pool = new TaskPool();
+    let count = 0;
+    pool.add(async () => {
+      count++;
+    });
+    await pool.drain();
+    assert.equal(count, 1);
+  });
+
+  it("retries failing tasks", async function () {
+    const pool = new TaskPool();
+    let attempts = 0;
+    pool.add(async () => {
+      attempts++;
+      if (attempts < 2) {
+        throw new Error("fail");
+      }
+    }, 1);
+    await pool.drain();
+    assert.equal(attempts, 2);
+  });
+});


### PR DESCRIPTION
## Summary
- introduce a TaskPool utility with retryable task tracking and shutdown draining
- wire the TaskPool into addon startup and shutdown to prevent lost work
- add unit tests validating task execution and retry behavior

## Testing
- `npm test` *(fails: fetch failed copying test libraries)*

------
https://chatgpt.com/codex/tasks/task_e_68ad9c0b27d88333ba964aabf150cbf7